### PR TITLE
CookieTokenStorage - change send to sendHeaders

### DIFF
--- a/src/Service/CookieTokenStorage.php
+++ b/src/Service/CookieTokenStorage.php
@@ -35,7 +35,7 @@ class CookieTokenStorage implements TokenStorageInterface
         $cookie = new Cookie($this->access_token_key, $token, 0, '/');
         $response = new Response();
         $response->headers->setCookie($cookie);
-        $response->send();
+        $response->sendHeaders();
 	}
 
 	public function getToken() : ?array


### PR DESCRIPTION
Hello,
Thank you for this package. I have a problem with redirecting after login. Redirect doesn't work because you are using the send for setting the cookie. It shows this error:
`Warning: Cannot modify header information - headers already sent`
 I've replaced send with sendHeader to fix redirects. Please accept this pull request.
Thank you.
