### PR TITLE
Support Symfony 6.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Google Drive API Bundle",
     "require": {
         "google/apiclient": "^2.2",
-        "symfony/framework-bundle": "^4.0|^5.1"
+        "symfony/framework-bundle": "^4.0|^5.1|^6.0"
     },
     "license": "MIT",
     "authors": [

--- a/src/Controller/VatriGoogleDriveAuthController.php
+++ b/src/Controller/VatriGoogleDriveAuthController.php
@@ -3,6 +3,7 @@
 namespace Vatri\GoogleDriveBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -27,10 +28,12 @@ class VatriGoogleDriveAuthController extends AbstractController
      */
     private $driveApiService;
 
-	public function __construct(ParameterBagInterface $parameterBag, SessionInterface $session, DriveApiService $driveApiService)
+	public function __construct(ParameterBagInterface $parameterBag, RequestStack $requestSatck, DriveApiService $driveApiService)
     {
+		try {
+            $this->session = $requestStack->getSession();
+        } catch (\Exception $exception){}
 		$this->parameterBag      = $parameterBag;
-		$this->session           = $session;
         $this->driveApiService = $driveApiService;
 	}
     /**

--- a/src/Controller/VatriGoogleDriveAuthController.php
+++ b/src/Controller/VatriGoogleDriveAuthController.php
@@ -28,7 +28,7 @@ class VatriGoogleDriveAuthController extends AbstractController
      */
     private $driveApiService;
 
-	public function __construct(ParameterBagInterface $parameterBag, RequestStack $requestSatck, DriveApiService $driveApiService)
+	public function __construct(ParameterBagInterface $parameterBag, RequestStack $requestStack, DriveApiService $driveApiService)
     {
 		try {
             $this->session = $requestStack->getSession();

--- a/src/Resources/config/vatri_google_drive.yaml
+++ b/src/Resources/config/vatri_google_drive.yaml
@@ -15,7 +15,7 @@ services:
 
   vatri_google_drive.api_service:
     class: Vatri\GoogleDriveBundle\Service\DriveApiService
-    arguments: [ '@session', '@parameter_bag', '@vatri_google_drive.cookie_token_storage' ]
+    arguments: [ '@request_stack', '@parameter_bag', '@vatri_google_drive.cookie_token_storage' ]
 
   # Alias:
   Vatri\GoogleDriveBundle\Service\DriveApiService: '@vatri_google_drive.api_service'
@@ -26,5 +26,5 @@ services:
     autoconfigure: true
     arguments:
       $parameterBag: '@parameter_bag'
-      $session: '@session'
+      $session: '@request_stack'
       $driveApiService: '@vatri_google_drive.api_service'

--- a/src/Resources/config/vatri_google_drive.yaml
+++ b/src/Resources/config/vatri_google_drive.yaml
@@ -26,5 +26,5 @@ services:
     autoconfigure: true
     arguments:
       $parameterBag: '@parameter_bag'
-      $session: '@request_stack'
+      $requestStack: '@request_stack'
       $driveApiService: '@vatri_google_drive.api_service'

--- a/src/Service/DriveApiService.php
+++ b/src/Service/DriveApiService.php
@@ -6,6 +6,7 @@ use Google_Service_Drive_DriveFile;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Vatri\GoogleDriveBundle\DriveServiceResponse;
 
 
@@ -33,9 +34,11 @@ class DriveApiService
     private $token_storage;
 
 
-    public function __construct(SessionInterface $session, ParameterBagInterface $parameters, TokenStorageInterface $tokenStorage)
+    public function __construct(RequestStack $requestStack, ParameterBagInterface $parameters, TokenStorageInterface $tokenStorage)
     {
-        $this->session = $session;
+        try {
+            $this->session = $requestStack->getSession();
+        } catch (\Exception $exception) {}
         $this->parameters = $parameters;
         $this->token_storage = $tokenStorage;
     }


### PR DESCRIPTION
Hello,
I've made some small changes to support Symfony 6.0.
1- Update composer.json to support SF6
2- Remove dependency to @session service because it is removed  in SF6 and use RequestStack instead of it
I appreciate it if you can check this PR and merge it.